### PR TITLE
Add explanation note to the signature list

### DIFF
--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -133,7 +133,7 @@
 </ol>
 
 
-<h3>Výzvu podpísali aj</h3>
+<h3>Výzvu podpísali aj (najnovších 210 podpisov)</h3>
 
 <% cache Vote.last do %>
   <ul class="signs">


### PR DESCRIPTION
As the difference between the number of the displayed signatures, and the number of the claimed signatures grows, it might cast some confusion. Explicitly mention that only last 210 signatures are displayed.
